### PR TITLE
event_trigger test fails if schema_triggers is preloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 *.so
 results/
+regression.out
+regression.diffs

--- a/expected/event_trigger.out
+++ b/expected/event_trigger.out
@@ -1,9 +1,4 @@
 -- Test that the CREATE/ALTER/DROP EVENT TRIGGER commands work as expected.
--- First, try creating a bogus event trigger before we have loaded the
--- extension.
-CREATE EVENT TRIGGER wont_work ON relation_create
-	EXECUTE PROCEDURE foo();
-ERROR:  unrecognized event name "relation_create"
 CREATE EXTENSION schema_triggers;
 -- Exercise the various cases that shouldn't work.
 CREATE EVENT TRIGGER wont_work ON phase_of_the_moon

--- a/sql/event_trigger.sql
+++ b/sql/event_trigger.sql
@@ -1,9 +1,5 @@
 -- Test that the CREATE/ALTER/DROP EVENT TRIGGER commands work as expected.
 
--- First, try creating a bogus event trigger before we have loaded the
--- extension.
-CREATE EVENT TRIGGER wont_work ON relation_create
-	EXECUTE PROCEDURE foo();
 CREATE EXTENSION schema_triggers;
 
 -- Exercise the various cases that shouldn't work.


### PR DESCRIPTION
I've seen most people installing cartodb jump the gun by setting up preloading of schema_triggers and _then_ running the tests. When this is done, the event_trigger test fails with

```
ERROR:  function foo() does not exist
```
- edited event_trigger test to not fail if schema_triggers is preloaded
- added regression outputs to gitignore

I'm not sure why the event_trigger test is the only one that attempts to check availability of schema_triggers before continuing the test. 

The other tests do not bother with this initial check. If schema_triggers is not available all the tests will fail right away at the first `CREATE EXTENSION schema_triggers` statement.
